### PR TITLE
correct GC

### DIFF
--- a/lib/resty/brotli/encoder.lua
+++ b/lib/resty/brotli/encoder.lua
@@ -208,9 +208,6 @@ function _M.compressStream (self, str)
       end
    end
 
-   ffi_gc(buff, C.free)
-   ffi_gc(buffer, C.free)
-
    if is_ok then
       return tab_concat(res)
    end


### PR DESCRIPTION
Hi there,
Thank you for this library!
nginx cored as soon as I started using it to decode/encode a brotli stream in lua_body_filter_block context.
free() is the failing call in all core dumps.
Basically `ffi.gc` " ...allows safe integration of unmanaged resources into the automatic memory management of the LuaJIT garbage collector." - like so `local p = ffi.gc(ffi.C.malloc(n), ffi.C.free)`

Managed resources, on the other hand, do not need explicit __GC metamethod finalizer to be associated.
`buff` and `buffer` are managed as they have been allocated with `ffi.new` and as such are automatically associated with a  `__gc metamethod` finalizer and will be gc'd when last reference to it is gone.
In which case assigning `ffi_gc(buff, C.free)` to `buff` and `buffer` probably causes some sort of a race condition in GC and nginx cores.

More [here](http://luajit.org/ext_ffi_api.html)